### PR TITLE
Refactor stream sketcher for configurable directory crawling

### DIFF
--- a/shared_scripts/stream_sketcher/config.yaml
+++ b/shared_scripts/stream_sketcher/config.yaml
@@ -5,16 +5,22 @@ tmp_root: "/scratch/genbank_wgs/wgs_tmp"
 state_db: "/scratch/genbank_wgs/wgs_state/wgs_sketcher.sqlite"
 log_path: "/scratch/genbank_wgs/wgs_logs/wgs_sketcher.log"
 
-include_regex: '^wgs\.[A-Z0-9]+(?:\.\d+)?\.fsa_nt\.gz$'
+# Match any FASTA nucleotide archive by default. Adjust as needed.
+include_regex: '.*\.fna\.gz$'
+exclude_regex: null
 
 max_crawl_concurrency: 4
+max_depth: 1
 max_concurrent_downloads: 8
 max_total_workers: 96
 rate_limit_bytes_per_sec: null
-user_agent: "WGS Sketcher/1.0 (+dmk333@psu.edu; admin=dmk333@psu.edu)"
+user_agent: "Stream Sketcher/1.0 (+dmk333@psu.edu; admin=dmk333@psu.edu)"
 error_retry_cooldown_seconds: 1800   # only revisit ERROR rows after 30 min
 error_max_total_tries: 20            # cap across the entire lifetime
 stale_seconds: 3600
+
+dry_run: false
+smoke_test_limit: null
 
 sourmash_params: "k=15,k=31,k=33,scaled=1000,noabund"
 sourmash_threads: 1

--- a/shared_scripts/stream_sketcher/run.sh
+++ b/shared_scripts/stream_sketcher/run.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-python -m wgs_sketcher --config config.yaml
+# Launch the refactored stream sketcher
+python -m stream_sketcher --config config.yaml

--- a/shared_scripts/stream_sketcher/stream_sketcher/crawler.py
+++ b/shared_scripts/stream_sketcher/stream_sketcher/crawler.py
@@ -1,21 +1,21 @@
-
 import asyncio
 import aiohttp
+import os
 import re
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, AsyncGenerator
 from .utils import LOG, is_target_file
 
 LISTING_HREF_RE = re.compile(r'href="([^"]+)"', re.IGNORECASE)
-SUBDIR_RE = re.compile(r'^(?:[A-Z]/|[A-Z0-9]{3}/)$')  # A/ or AAA/
 
-async def fetch_text(session: aiohttp.ClientSession, url: str, timeout: int=120) -> Optional[str]:
+async def fetch_text(session: aiohttp.ClientSession, url: str, timeout: int = 120) -> Optional[str]:
+    """Fetch ``url`` returning the response text or ``None`` on failure."""
     try:
         async with session.get(url, timeout=timeout) as resp:
             if resp.status != 200:
                 LOG.warning("GET %s -> %s", url, resp.status)
                 return None
             return await resp.text()
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - network errors
         LOG.warning("Error fetching %s: %r", url, e)
         return None
 
@@ -23,47 +23,70 @@ def parse_listing_for_hrefs(html: str) -> List[str]:
     return LISTING_HREF_RE.findall(html)
 
 def partition_dirs_and_files(hrefs: List[str]) -> Tuple[List[str], List[str]]:
-    subdirs = []
-    files = []
+    """Split a list of hrefs from a directory listing into directories and files."""
+    subdirs: List[str] = []
+    files: List[str] = []
     for h in hrefs:
+        # skip parent/self links and any absolute URLs
         if h in ("../", "./"):
             continue
-        if SUBDIR_RE.match(h):
-            subdirs.append(h)
-        elif h.endswith(".gz"):
-            files.append(h)
+        if h.startswith('/') or h.startswith('http'):
+            # absolute links would cause us to re-crawl from the root
+            continue
+        if h.endswith('/'):
+            subdirs.append(h.rstrip('/'))
         else:
-            pass
+            files.append(h)
     return subdirs, files
 
-async def crawl_wgs(base_url: str, include_re: str, max_concurrency: int = 4, headers: Optional[dict] = None):
+async def crawl_ftp(base_url: str,
+                    include_re: str,
+                    exclude_re: Optional[str] = None,
+                    max_depth: Optional[int] = 1,
+                    max_concurrency: int = 4,
+                    headers: Optional[dict] = None) -> AsyncGenerator[Tuple[str, str, str, Optional[int], Optional[str]], None]:
+    """Recursively crawl ``base_url`` yielding files that match ``include_re``.
 
+    ``max_depth`` specifies how many directory levels below ``base_url`` should
+    be traversed.  ``None`` means unlimited depth, ``0`` only inspects the root
+    directory, ``1`` (the default) inspects direct children, etc.
+    """
+    base_url = base_url.rstrip('/')
     conn = aiohttp.TCPConnector(limit_per_host=max_concurrency, limit=max_concurrency)
     async with aiohttp.ClientSession(connector=conn, headers=headers) as session:
-        index_html = await fetch_text(session, base_url + "/")
-        if not index_html:
-            raise RuntimeError(f"Failed to fetch root listing: {base_url}/")
-        hrefs = parse_listing_for_hrefs(index_html)
-        subdirs, _ = partition_dirs_and_files(hrefs)
-        LOG.info("Found %d subdirs at root.", len(subdirs))
         sem = asyncio.Semaphore(max_concurrency)
 
-        async def crawl_subdir(subdir: str):
-            url = f"{base_url}/{subdir}"
+        async def crawl_dir(rel: str, depth: int):
+            url = f"{base_url}/{rel}" if rel else base_url
             async with sem:
-                html = await fetch_text(session, url)
+                html = await fetch_text(session, url + '/')
             if not html:
                 return []
-            hrefs2 = parse_listing_for_hrefs(html)
-            _, files = partition_dirs_and_files(hrefs2)
+            hrefs = parse_listing_for_hrefs(html)
+            subdirs, files = partition_dirs_and_files(hrefs)
             results = []
             for f in files:
-                if is_target_file(f, include_re=include_re):
-                    results.append((subdir.strip("/"), f, f"{base_url}/{subdir}{f}", None, None))
-            LOG.info("Subdir %s: %d target files.", subdir.strip("/"), len(results))
+                if is_target_file(f, include_re, exclude_re):
+                    results.append((rel, f, f"{url}/{f}", None, None))
+            if max_depth is None or depth < max_depth:
+                tasks = []
+                for sd in subdirs:
+                    next_rel = f"{rel}/{sd}" if rel else sd
+                    tasks.append(asyncio.create_task(crawl_dir(next_rel, depth + 1)))
+                for task in asyncio.as_completed(tasks):
+                    results.extend(await task)
             return results
 
-        tasks = [asyncio.create_task(crawl_subdir(sd)) for sd in subdirs]
+        top_html = await fetch_text(session, base_url + '/')
+        if not top_html:
+            raise RuntimeError(f"Failed to fetch root listing: {base_url}/")
+        hrefs = parse_listing_for_hrefs(top_html)
+        subdirs, files = partition_dirs_and_files(hrefs)
+        for f in files:
+            if is_target_file(f, include_re, exclude_re):
+                yield ('', f, f"{base_url}/{f}", None, None)
+        tasks = [asyncio.create_task(crawl_dir(sd, 1)) for sd in subdirs]
         for task in asyncio.as_completed(tasks):
             for item in await task:
                 yield item
+


### PR DESCRIPTION
## Summary
- generalize utilities with include/exclude regex and generic sharding
- add recursive FTP crawler with configurable depth
- support dry-run and smoke-test modes in scheduler via config
- filter absolute links so crawler builds URLs correctly

## Testing
- `bash run.sh` *(fails: Failed to fetch root listing: https://ftp.ncbi.nlm.nih.gov/genbank/wgs/)*
- `python - <<'PY' ...` (local aiohttp server) to confirm crawler skips absolute links and emits expected files

------
https://chatgpt.com/codex/tasks/task_b_68b204e655f08328b0bbd90679ec1f11