### PR TITLE
Refactor stream sketcher for configurable crawling

### DIFF
--- a/shared_scripts/stream_sketcher/config.yaml
+++ b/shared_scripts/stream_sketcher/config.yaml
@@ -1,23 +1,31 @@
+base_url: "https://ftp.ncbi.nlm.nih.gov/genomes/all"
+output_root: "/scratch/genbank_genomes_all/genomes_all_sketches"
+tmp_root: "/scratch/genbank_genomes_all/genomes_all_tmp"
+state_db: "/scratch/genbank_genomes_all/_state/sketcher.sqlite"
+log_path: "/scratch/genbank_genomes_all/logs/sketcher.log"
 
-base_url: "https://ftp.ncbi.nlm.nih.gov/genbank/wgs"
-output_root: "/scratch/genbank_wgs/wgs_sketches"
-tmp_root: "/scratch/genbank_wgs/wgs_tmp"
-state_db: "/scratch/genbank_wgs/wgs_state/wgs_sketcher.sqlite"
-log_path: "/scratch/genbank_wgs/wgs_logs/wgs_sketcher.log"
-
-include_regex: '^wgs\.[A-Z0-9]+(?:\.\d+)?\.fsa_nt\.gz$'
+# Match any FASTA nucleotide archive by default. Adjust as needed.
+include_regex: '.*\.fna\.gz$'
+exclude_regex: null
 
 max_crawl_concurrency: 4
+max_depth: null
 max_concurrent_downloads: 8
 max_total_workers: 96
 rate_limit_bytes_per_sec: null
-user_agent: "WGS Sketcher/1.0 (+dmk333@psu.edu; admin=dmk333@psu.edu)"
+user_agent: "Stream Sketcher/1.0 (+dmk333@psu.edu; admin=dmk333@psu.edu)"
 error_retry_cooldown_seconds: 1800   # only revisit ERROR rows after 30 min
 error_max_total_tries: 20            # cap across the entire lifetime
 stale_seconds: 3600
+
+dry_run: true
+smoke_test_limit: null
 
 sourmash_params: "k=15,k=31,k=33,scaled=1000,noabund"
 sourmash_threads: 1
 
 request_timeout_seconds: 3600
 max_retries: 8
+
+shard_modulus: 512
+log_level: INFO

--- a/shared_scripts/stream_sketcher/run.sh
+++ b/shared_scripts/stream_sketcher/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-python -m wgs_sketcher --config config.yaml
+python -m stream_sketcher --config config.yaml

--- a/shared_scripts/stream_sketcher/stream_sketcher/db.py
+++ b/shared_scripts/stream_sketcher/stream_sketcher/db.py
@@ -40,7 +40,6 @@ class DB:
                 if stmt.strip():
                     self.conn.execute(stmt)
 
-    # --- add to wgs_sketcher/db.py (class DB) ---
     def claim_next(self,
                    error_cooldown_seconds: int = 3600,
                    error_max_total_tries: int = 20) -> Optional[Tuple[int, str, str, str]]:


### PR DESCRIPTION
## Summary
- generalize crawler to recursively explore arbitrary FTP hierarchies
- add configurable include/exclude patterns, depth limits, dry-run and smoke-test modes
- shard outputs by hashing filename modulo a configurable value

## Testing
- `python -m stream_sketcher --config /tmp/dry_config.yaml` *(fails: Network is unreachable)*
- `python -m stream_sketcher --config /tmp/smoke_config.yaml` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_68b2135b7b608328b51ac1ca196f4ef5